### PR TITLE
changed gbk2faa.pl command to use the conda-perl

### DIFF
--- a/tools/kaiju_db_custom.sm
+++ b/tools/kaiju_db_custom.sm
@@ -7,7 +7,7 @@ rule kaiju_db_custom_1:
 	shell: 
 		"""
 		if [ -d "{params.seq_folder}" ]; then
-			{config[tool_alt_path][kaiju]}gbk2faa.pl <(cat {params.seq_folder}/*.gbff) {output.faa} > {log} 2>&1
+			/usr/bin/env perl {config[tool_alt_path][kaiju]}$(which kaiju | sed 's|bin/kaiju|bin/|g')gbk2faa.pl <(cat {params.seq_folder}/*.gbff) {output.faa} > {log} 2>&1
 		else
 			echo "Custom database ({wildcards.database}) -> '{params.seq_folder}': No such file or directory" > {log}
 		fi


### PR DESCRIPTION
tldr; The gbk2faa.pl script uses a locally installed perl (/usr/bin/perl), which did not work on the machine I use. I modified the command to use the conda-installed perl.

---

When running MetaMeta, the rule 'kaiju_db_custom_1' failed with the error: 
```Can't locate IO/Uncompress/AnyUncompress.pm in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at - line 2.
BEGIN failed--compilation aborted at - line 2.```
So it seemed to look for perl libraries installed locally, not those provided by conda. I figured this was probably due to the line `#! /usr/bin/perl -w` in the gbk2faa.pl script. Therefore, I changed the shell command in the Snakefile to `/usr/bin/env perl gbk2faa.pl`.
Then, the process failed with the message `Can't open perl script "gbk2faa.pl": No such file or directory`, so apparently the script could not be found anymore. I decided to fix that by appending the absolute path to the script by searching for the conda environment directory with `which` and prepend that to `gb2faa.pl`. Now it all seems to work as intended.